### PR TITLE
nvim: add comment text objects via mini.ai

### DIFF
--- a/doc/zero-extra.md
+++ b/doc/zero-extra.md
@@ -9,9 +9,9 @@ A port of [vim-textobj-comment](https://github.com/glts/vim-textobj-comment) to 
 ### Usage
 
 ```lua
-require('mini.ai').setup({
+require("mini.ai").setup({
   custom_textobjects = {
-    c = require('zero.extra').gen_ai_spec.comment(),
+    c = require("zero.extra").gen_ai_spec.comment(),
   },
 })
 ```
@@ -138,9 +138,9 @@ In Lua, replace `find_all_paired_comment_blocks` with this version that merges a
 local function find_all_paired_comment_blocks(lines, open, close)
   local blocks = {}
   local total = #lines
-  local open_re = '^%s*' .. vim.pesc(open)
-  local close_re = vim.pesc(close) .. '%s*$'
-  local single_re = '^%s*' .. vim.pesc(open) .. '.-' .. vim.pesc(close) .. '%s*$'
+  local open_re = "^%s*" .. vim.pesc(open)
+  local close_re = vim.pesc(close) .. "%s*$"
+  local single_re = "^%s*" .. vim.pesc(open) .. ".-" .. vim.pesc(close) .. "%s*$"
   local ln = 1
   while ln <= total do
     if lines[ln]:match(open_re) then

--- a/doc/zero-extra.md
+++ b/doc/zero-extra.md
@@ -95,3 +95,41 @@ Because the spec function returns **all** comment regions in the buffer as an ar
 - `vim.pesc` is used for all pattern escaping.
 - Simple leader flag check uses `^[bnOf]*$` (strict — excludes middle-of-block `m`, start `s`, end `e` markers).
 - Regions are sorted by `(from.line, from.col)` before being returned so `mini.ai` search works correctly.
+
+## Known differences from vim-textobj-comment
+
+### Consecutive single-line `/* */` blocks are not merged
+
+The original `vim-textobj-comment` merges adjacent single-line paired comments into one block:
+
+```c
+/* line one */
+/* line two */   ← treated as one big comment by vim-textobj-comment
+/* line three */
+```
+
+With `vim-textobj-comment`, `ac` on any of these lines selects all three. In this implementation each `/* ... */` is returned as a **separate region**. This was a deliberate choice — separate regions are more flexible with `mini.ai`'s next/last navigation (`anc`/`alc` can target each block individually).
+
+If you want to implement merging later, the algorithm from `vim-textobj-comment`'s `s:FindNearestPair()` is:
+
+```vim
+" After finding a single-line paired block at [start, end] where start == end:
+" Walk upward from start, merging consecutive single-line blocks
+let ln = start[0] - 1
+while ln > 0
+  let col = match(getline(ln), startre)   " startre matches /^...*end..$/
+  if col < 0 | break | endif
+  let [start[0], start[1]] = [ln, col+1]
+  let ln -= 1
+endwhile
+" Walk downward from end, merging consecutive single-line blocks
+let ln = end[0] + 1
+while ln <= line("$")
+  let col = match(getline(ln), endre)
+  if col < 0 | break | endif
+  let [end[0], end[1]] = [ln, col+1]
+  let ln += 1
+endwhile
+```
+
+In Lua, this would be applied inside `find_all_paired_comment_blocks` after a single-line block (`start_line == end_line`) is found: walk up/down merging adjacent single-line `/* */` lines before appending to `blocks`.

--- a/doc/zero-extra.md
+++ b/doc/zero-extra.md
@@ -1,0 +1,97 @@
+# zero/extra.lua
+
+Extra textobject specifications for [mini.ai](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-ai.md).
+
+## `M.gen_ai_spec.comment`
+
+A port of [vim-textobj-comment](https://github.com/glts/vim-textobj-comment) to the `mini.ai` textobject specification.
+
+### Usage
+
+```lua
+require('mini.ai').setup({
+  custom_textobjects = {
+    c = require('zero.extra').gen_ai_spec.comment(),
+  },
+})
+```
+
+### Textobjects
+
+| Key | Description |
+|-----|-------------|
+| `ac` | **around** comment — selects the full comment including delimiters |
+| `ic` | **inner** comment — selects only the comment content, stripping delimiters and surrounding whitespace |
+| `anc` / `inc` | next comment |
+| `alc` / `ilc` | last (previous) comment |
+
+### Comment types detected
+
+Comment leaders are read from `'comments'` (`&comments`) with a fallback to `'commentstring'` (`&commentstring`), so it automatically adapts to any filetype.
+
+#### Simple line comments
+
+Lines whose content starts with the comment leader (e.g. `//`, `#`, `--`).
+Contiguous runs of comment lines are treated as a single block.
+
+```lua
+-- this is one block
+-- spanning two lines
+
+# another block
+```
+
+- `ac` — selects the whole block, linewise (`V` mode)
+- `ic` — selects the content after stripping leaders and surrounding whitespace, charwise
+
+#### Paired block comments
+
+Open/close delimiter pairs (e.g. `/* ... */`, `--[[ ... ]]`).
+
+```lua
+/* single-line block */
+
+/*
+ * multi-line block
+ */
+```
+
+- `ac` on multi-line — selects the whole block, linewise (`V` mode)
+- `ac` on single-line — selects the whole block, charwise
+- `ic` — selects content between delimiters, trimming whitespace, charwise
+
+#### Inline / end-of-line comments
+
+Comments that appear after code on the same line.
+
+```lua
+local x = 1  -- end-of-line comment
+local y = f(/* inline */ 2)
+```
+
+- `ac` — selects from the comment leader to end of comment, charwise
+- `ic` — selects comment content only, charwise
+
+### Visual mode behaviour
+
+| Selection | `vis_mode` | Result |
+|-----------|-----------|--------|
+| `ac` on multi-line block | `V` | Linewise — whole lines selected |
+| `ac` on single-line paired | charwise | Only the `/* ... */` span |
+| `ac` on inline comment | `v` | Charwise — prevents inheriting `V` from a prior `ac` |
+| `ic` (all types) | `v` | Always charwise — prevents inheriting `V` from `ac` |
+
+### next / last variants
+
+Because the spec function returns **all** comment regions in the buffer as an array, `mini.ai` can apply its full `cover / next / prev / nearest` search logic. This enables:
+
+- `anc` / `inc` — jump to and select the **next** comment
+- `alc` / `ilc` — jump to and select the **last** (previous) comment
+- Repeated `ac` increments through all comments in order
+
+### Implementation notes
+
+- All buffer lines are loaded once with `vim.api.nvim_buf_get_lines` at invocation time; no per-line `vim.fn.getline` calls.
+- `vim.pesc` is used for all pattern escaping.
+- Simple leader flag check uses `^[bnOf]*$` (strict — excludes middle-of-block `m`, start `s`, end `e` markers).
+- Regions are sorted by `(from.line, from.col)` before being returned so `mini.ai` search works correctly.

--- a/doc/zero-extra.md
+++ b/doc/zero-extra.md
@@ -132,4 +132,48 @@ while ln <= line("$")
 endwhile
 ```
 
-In Lua, this would be applied inside `find_all_paired_comment_blocks` after a single-line block (`start_line == end_line`) is found: walk up/down merging adjacent single-line `/* */` lines before appending to `blocks`.
+In Lua, replace `find_all_paired_comment_blocks` with this version that merges adjacent single-line blocks:
+
+```lua
+local function find_all_paired_comment_blocks(lines, open, close)
+  local blocks = {}
+  local total = #lines
+  local open_re = '^%s*' .. vim.pesc(open)
+  local close_re = vim.pesc(close) .. '%s*$'
+  local single_re = '^%s*' .. vim.pesc(open) .. '.-' .. vim.pesc(close) .. '%s*$'
+  local ln = 1
+  while ln <= total do
+    if lines[ln]:match(open_re) then
+      local start_line = ln
+      local found = false
+      for el = ln, total do
+        if lines[el]:match(close_re) then
+          local sl, end_line = start_line, el
+          -- Merge consecutive single-line /* */ blocks
+          if sl == end_line then
+            local up = sl - 1
+            while up >= 1 and lines[up]:match(single_re) do
+              sl = up
+              up = up - 1
+            end
+            local down = end_line + 1
+            while down <= total and lines[down]:match(single_re) do
+              end_line = down
+              down = down + 1
+            end
+          end
+          table.insert(blocks, { start_line = sl, end_line = end_line })
+          ln = end_line
+          found = true
+          break
+        end
+      end
+      if not found then break end
+    end
+    ln = ln + 1
+  end
+  return blocks
+end
+```
+
+Note: with merging enabled, `anc`/`alc` will treat the merged group as one unit, losing the ability to target individual `/* */` lines.

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -1,0 +1,282 @@
+local M = {}
+
+M.gen_ai_spec = {}
+
+-- Port of vim-textobj-comment to mini.ai textobject specification.
+-- Supports both simple (// ...) and paired (/* ... */) comment delimiters.
+-- Uses the 'comments' and 'commentstring' options to detect comment leaders.
+M.gen_ai_spec.comment = function()
+  -- Parse 'comments' option into {flags, leader} pairs, with 'commentstring' as fallback.
+  local function get_leaders()
+    local comments = vim.bo.comments
+    local leaders = {}
+
+    if comments ~= '' then
+      for entry in vim.gsplit(comments, ',') do
+        local colon = entry:find(':')
+        if colon then
+          local flags = entry:sub(1, colon - 1)
+          local leader = entry:sub(colon + 1)
+          table.insert(leaders, { flags = flags, leader = leader })
+        end
+      end
+    end
+
+    -- Fallback to commentstring if no leaders found
+    if #leaders == 0 then
+      local cms = vim.bo.commentstring
+      if cms:find('%%s') then
+        local before, after = cms:match('^(.-)%s*%%s(.-)%s*$')
+        if before and before ~= '' and after and after ~= '' then
+          table.insert(leaders, { flags = 's', leader = before })
+          table.insert(leaders, { flags = 'e', leader = after })
+        elseif before and before ~= '' then
+          table.insert(leaders, { flags = '', leader = before })
+        end
+      end
+    end
+
+    -- Separate into simple and paired leaders
+    local simple = {}
+    local paired = {} -- list of {open, close}
+
+    local se_leaders = vim.tbl_filter(function(l)
+      return l.flags:match('[se]')
+    end, leaders)
+
+    local i = 1
+    while i <= #se_leaders do
+      local s = se_leaders[i]
+      local e = se_leaders[i + 1]
+      if s and e and s.flags:match('s') and e.flags:match('e') then
+        table.insert(paired, { open = s.leader, close = e.leader })
+        i = i + 2
+      else
+        i = i + 1
+      end
+    end
+
+    for _, l in ipairs(leaders) do
+      -- Simple leaders: flags contain only b, n, O or are empty (no s/e/m)
+      if not l.flags:match('[sem]') then
+        table.insert(simple, l.leader)
+      end
+    end
+
+    return simple, paired
+  end
+
+  local function escape_pattern(s)
+    return s:gsub('[%(%)%.%%%+%-%*%?%[%]%^%$]', '%%%1')
+  end
+
+  local function is_blank(lnum)
+    return vim.fn.getline(lnum):match('^%s*$') ~= nil
+  end
+
+  -- Find a contiguous block of simple comment lines that includes lnum.
+  local function find_simple_block(lnum, simple_re)
+    if not vim.fn.getline(lnum):match(simple_re) then
+      return nil
+    end
+    local start_line = lnum
+    while start_line > 1 and vim.fn.getline(start_line - 1):match(simple_re) do
+      start_line = start_line - 1
+    end
+    local end_line = lnum
+    while end_line < vim.fn.line('$') and vim.fn.getline(end_line + 1):match(simple_re) do
+      end_line = end_line + 1
+    end
+    return start_line, end_line
+  end
+
+  -- Find a paired comment block that contains or is nearest above lnum.
+  local function find_paired_block(lnum, open, close, upwards)
+    local open_re = '^%s*' .. escape_pattern(open)
+    local close_re = escape_pattern(close) .. '%s*$'
+    local total = vim.fn.line('$')
+
+    if upwards then
+      -- Search above cursor for the nearest paired comment end
+      for ln = lnum - 1, 1, -1 do
+        if vim.fn.getline(ln):match(close_re) then
+          local end_line = ln
+          -- Now find the matching open
+          for sl = ln, 1, -1 do
+            if vim.fn.getline(sl):match(open_re) then
+              return sl, end_line
+            end
+          end
+        end
+      end
+      return nil
+    else
+      -- Search from lnum downward for a paired comment containing or starting at lnum
+      for ln = lnum, total do
+        if vim.fn.getline(ln):match(close_re) then
+          local end_line = ln
+          -- Search upward from end_line for the matching open
+          for sl = end_line, 1, -1 do
+            if vim.fn.getline(sl):match(open_re) then
+              if sl <= lnum then
+                return sl, end_line
+              end
+              break
+            end
+          end
+          break
+        end
+      end
+      return nil
+    end
+  end
+
+  return function(ai_type)
+    local simple_leaders, paired_leaders = get_leaders()
+    if #simple_leaders == 0 and #paired_leaders == 0 then
+      return nil
+    end
+
+    local lnum = vim.fn.line('.')
+
+    -- Build a combined simple leader pattern
+    local simple_re = nil
+    if #simple_leaders > 0 then
+      local parts = vim.tbl_map(function(l)
+        return escape_pattern(l)
+      end, simple_leaders)
+      simple_re = '^%s*(' .. table.concat(parts, '|') .. ')'
+    end
+
+    -- 1. Try simple line comment at cursor
+    if simple_re then
+      local start_line, end_line = find_simple_block(lnum, simple_re)
+      if start_line then
+        if ai_type == 'i' then
+          -- Strip comment leader from each line; select trimmed content
+          local first_content_col = nil
+          for ln = start_line, end_line do
+            local line = vim.fn.getline(ln)
+            for _, leader in ipairs(simple_leaders) do
+              local _, e = line:find('^%s*' .. escape_pattern(leader))
+              if e then
+                local rest = line:sub(e + 1)
+                local trimmed_start = rest:find('%S')
+                if trimmed_start then
+                  local col = e + trimmed_start
+                  if not first_content_col then
+                    first_content_col = col
+                  end
+                end
+                break
+              end
+            end
+          end
+          local last_line = vim.fn.getline(end_line)
+          local last_col = #last_line:match('(.-)%s*$')
+          return {
+            from = { line = start_line, col = first_content_col or 1 },
+            to = { line = end_line, col = math.max(last_col, 1) },
+          }
+        else
+          -- 'a': select whole lines
+          local end_col = #vim.fn.getline(end_line)
+          return {
+            from = { line = start_line, col = 1 },
+            to = { line = end_line, col = math.max(end_col, 1) },
+          }
+        end
+      end
+    end
+
+    -- 2. Try paired comment containing or surrounding cursor
+    for _, pair in ipairs(paired_leaders) do
+      local start_line, end_line = find_paired_block(lnum, pair.open, pair.close, false)
+      if start_line then
+        if ai_type == 'i' then
+          -- Inner: skip open/close delimiters
+          local from_line, from_col, to_line, to_col
+          local open_line = vim.fn.getline(start_line)
+          local _, oe = open_line:find(escape_pattern(pair.open))
+          local rest_after_open = open_line:sub((oe or 0) + 1)
+          local nonws = rest_after_open:find('%S')
+          if nonws and start_line == end_line then
+            -- Single-line paired comment
+            local close_line = vim.fn.getline(end_line)
+            local cs = close_line:find('%s*' .. escape_pattern(pair.close) .. '%s*$')
+            from_line = start_line
+            from_col = (oe or 0) + nonws
+            to_line = end_line
+            to_col = (cs or #close_line + 1) - 1
+            if to_col < from_col then
+              return nil
+            end
+          else
+            -- Multi-line: first non-blank after open, last non-blank before close
+            from_line = start_line
+            from_col = (oe or 0) + (nonws or #rest_after_open + 1)
+            if not nonws then
+              -- open is on its own line, start content from next line
+              from_line = start_line + 1
+              local next_line = vim.fn.getline(from_line)
+              local col = next_line:find('%S')
+              from_col = col or 1
+            end
+            local close_line_str = vim.fn.getline(end_line)
+            local cs = close_line_str:find('%s*' .. escape_pattern(pair.close) .. '%s*$')
+            local content_before_close = close_line_str:sub(1, (cs or #close_line_str + 1) - 1)
+            local last_nonws = #content_before_close:match('(.-)%s*$')
+            to_line = end_line
+            to_col = last_nonws
+            if last_nonws == 0 then
+              to_line = end_line - 1
+              local prev = vim.fn.getline(to_line)
+              to_col = #prev:match('(.-)%s*$')
+            end
+          end
+          return {
+            from = { line = from_line, col = from_col },
+            to = { line = to_line, col = math.max(to_col, 1) },
+          }
+        else
+          local end_col = #vim.fn.getline(end_line)
+          return {
+            from = { line = start_line, col = 1 },
+            to = { line = end_line, col = math.max(end_col, 1) },
+          }
+        end
+      end
+    end
+
+    -- 3. Search upward for nearest comment
+    if simple_re then
+      for ln = lnum - 1, 1, -1 do
+        if vim.fn.getline(ln):match(simple_re) then
+          local start_line, end_line = find_simple_block(ln, simple_re)
+          if start_line then
+            local end_col = #vim.fn.getline(end_line)
+            return {
+              from = { line = start_line, col = 1 },
+              to = { line = end_line, col = math.max(end_col, 1) },
+            }
+          end
+        end
+      end
+    end
+
+    for _, pair in ipairs(paired_leaders) do
+      local start_line, end_line = find_paired_block(lnum, pair.open, pair.close, true)
+      if start_line then
+        local end_col = #vim.fn.getline(end_line)
+        return {
+          from = { line = start_line, col = 1 },
+          to = { line = end_line, col = math.max(end_col, 1) },
+        }
+      end
+    end
+
+    return nil
+  end
+end
+
+return M

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -72,63 +72,54 @@ local function match_simple_leader(line, simple_leaders)
   return nil
 end
 
--- Find a contiguous block of simple comment lines that includes lnum.
--- Returns start_line, end_line, matched_leader or nil.
-local function find_simple_comment_block(lnum, simple_leaders)
-  local line = vim.fn.getline(lnum)
-  local leader = match_simple_leader(line, simple_leaders)
-  if not leader then
-    return nil
+-- Scan the whole buffer and return all contiguous simple comment blocks as
+-- a list of {start_line, end_line, leader}.
+local function find_all_simple_comment_blocks(simple_leaders)
+  local blocks = {}
+  local total = vim.fn.line('$')
+  local ln = 1
+  while ln <= total do
+    local leader = match_simple_leader(vim.fn.getline(ln), simple_leaders)
+    if leader then
+      local leader_re = '^%s*' .. vim.pesc(leader)
+      local start_line = ln
+      while ln < total and vim.fn.getline(ln + 1):match(leader_re) do
+        ln = ln + 1
+      end
+      table.insert(blocks, { start_line = start_line, end_line = ln, leader = leader })
+    end
+    ln = ln + 1
   end
-
-  local leader_re = '^%s*' .. vim.pesc(leader)
-  local start_line = lnum
-  while start_line > 1 and vim.fn.getline(start_line - 1):match(leader_re) do
-    start_line = start_line - 1
-  end
-  local end_line = lnum
-  while end_line < vim.fn.line('$') and vim.fn.getline(end_line + 1):match(leader_re) do
-    end_line = end_line + 1
-  end
-  return start_line, end_line, leader
+  return blocks
 end
 
--- Find a paired comment block (/* ... */) that contains lnum, or the nearest one above
--- when upwards=true.
-local function find_paired_comment_block(lnum, open, close, upwards)
+-- Scan the whole buffer and return all paired comment blocks (/* ... */) as
+-- a list of {start_line, end_line}.
+local function find_all_paired_comment_blocks(open, close)
+  local blocks = {}
+  local total = vim.fn.line('$')
   local open_re = '^%s*' .. vim.pesc(open)
   local close_re = vim.pesc(close) .. '%s*$'
-  local total = vim.fn.line('$')
-
-  if upwards then
-    for ln = lnum - 1, 1, -1 do
-      if vim.fn.getline(ln):match(close_re) then
-        local end_line = ln
-        for sl = ln, 1, -1 do
-          if vim.fn.getline(sl):match(open_re) then
-            return sl, end_line
-          end
+  local ln = 1
+  while ln <= total do
+    if vim.fn.getline(ln):match(open_re) then
+      local start_line = ln
+      local found = false
+      for el = ln, total do
+        if vim.fn.getline(el):match(close_re) then
+          table.insert(blocks, { start_line = start_line, end_line = el })
+          ln = el
+          found = true
+          break
         end
       end
-    end
-    return nil
-  else
-    for ln = lnum, total do
-      if vim.fn.getline(ln):match(close_re) then
-        local end_line = ln
-        for sl = end_line, 1, -1 do
-          if vim.fn.getline(sl):match(open_re) then
-            if sl <= lnum then
-              return sl, end_line
-            end
-            break
-          end
-        end
+      if not found then
         break
       end
     end
-    return nil
+    ln = ln + 1
   end
+  return blocks
 end
 
 -- Build the inner region for a simple comment block: strip leader and trailing whitespace.
@@ -206,6 +197,8 @@ end
 -- Port of vim-textobj-comment to mini.ai textobject specification.
 -- Supports both simple (// ...) and paired (/* ... */) comment delimiters.
 -- Uses the 'comments' and 'commentstring' options to determine comment leaders.
+-- Returns all comment regions in the buffer so mini.ai can apply its
+-- cover/next/prev/nearest search methods (enabling next/last variants).
 M.gen_ai_spec.comment = function()
   return function(ai_type)
     local simple_leaders, paired_leaders = get_comment_leaders()
@@ -213,50 +206,49 @@ M.gen_ai_spec.comment = function()
       return nil
     end
 
-    local lnum = vim.fn.line('.')
+    local regions = {}
 
-    -- 1. Try simple line comment at cursor
-    local start_line, end_line, leader = find_simple_comment_block(lnum, simple_leaders)
-    if start_line then
+    for _, block in ipairs(find_all_simple_comment_blocks(simple_leaders)) do
       if ai_type == 'i' then
-        return simple_comment_inner(start_line, end_line, leader)
+        local region = simple_comment_inner(block.start_line, block.end_line, block.leader)
+        if region then
+          table.insert(regions, region)
+        end
       else
-        local end_col = #vim.fn.getline(end_line)
-        return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
+        local end_col = #vim.fn.getline(block.end_line)
+        table.insert(regions, {
+          from = { line = block.start_line, col = 1 },
+          to = { line = block.end_line, col = math.max(end_col, 1) },
+        })
       end
     end
 
-    -- 2. Try paired comment containing cursor
     for _, pair in ipairs(paired_leaders) do
-      start_line, end_line = find_paired_comment_block(lnum, pair.open, pair.close, false)
-      if start_line then
+      for _, block in ipairs(find_all_paired_comment_blocks(pair.open, pair.close)) do
         if ai_type == 'i' then
-          return paired_comment_inner(start_line, end_line, pair.open, pair.close)
+          local region = paired_comment_inner(block.start_line, block.end_line, pair.open, pair.close)
+          if region then
+            table.insert(regions, region)
+          end
         else
-          local end_col = #vim.fn.getline(end_line)
-          return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
+          local end_col = #vim.fn.getline(block.end_line)
+          table.insert(regions, {
+            from = { line = block.start_line, col = 1 },
+            to = { line = block.end_line, col = math.max(end_col, 1) },
+          })
         end
       end
     end
 
-    -- 3. Search upward for nearest comment (simple first, then paired)
-    for ln = lnum - 1, 1, -1 do
-      start_line, end_line, leader = find_simple_comment_block(ln, simple_leaders)
-      if start_line then
-        local end_col = #vim.fn.getline(end_line)
-        return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
+    -- Sort regions by start position so mini.ai search works correctly
+    table.sort(regions, function(a, b)
+      if a.from.line ~= b.from.line then
+        return a.from.line < b.from.line
       end
-    end
+      return a.from.col < b.from.col
+    end)
 
-    for _, pair in ipairs(paired_leaders) do
-      start_line, end_line = find_paired_comment_block(lnum, pair.open, pair.close, true)
-      if start_line then
-        local end_col = #vim.fn.getline(end_line)
-        return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
-      end
-    end
-
-    return nil
+    return regions
   end
 end
 

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -117,6 +117,51 @@ local function find_all_paired_comment_blocks(lines, open, close)
   return blocks
 end
 
+-- Scan each line for inline/end-of-line simple comments (leader not at line start).
+-- e.g. "code  // trailing comment" or "code  # remark"
+-- Returns a list of {line, col_start, col_end, leader}.
+local function find_all_inline_simple_comments(lines, simple_leaders)
+  local results = {}
+  for ln, line in ipairs(lines) do
+    -- Skip pure comment lines (already handled by find_all_simple_comment_blocks)
+    if not match_simple_leader(line, simple_leaders) then
+      for _, leader in ipairs(simple_leaders) do
+        local col = line:find(vim.pesc(leader))
+        if col and col > 1 then
+          table.insert(results, { line = ln, col_start = col, col_end = #line, leader = leader })
+          break -- take the first matching leader per line
+        end
+      end
+    end
+  end
+  return results
+end
+
+-- Scan each line for inline paired comments (/* ... */ not at line start).
+-- Returns a list of {line, col_start, col_end, open, close}.
+local function find_all_inline_paired_comments(lines, open, close)
+  local results = {}
+  local esc_open = vim.pesc(open)
+  local esc_close = vim.pesc(close)
+  local open_re = '^%s*' .. esc_open
+  for ln, line in ipairs(lines) do
+    -- Skip lines where the open is at line start (handled by paired block scanner)
+    if not line:match(open_re) then
+      local pos = 1
+      while true do
+        local s = line:find(esc_open, pos)
+        if not s then break end
+        local e = line:find(esc_close, s + #open)
+        if not e then break end
+        local col_end = e + #close - 1
+        table.insert(results, { line = ln, col_start = s, col_end = col_end, open = open, close = close })
+        pos = col_end + 1
+      end
+    end
+  end
+  return results
+end
+
 -- Build the inner region for a simple comment block: strip leader and trailing whitespace.
 local function simple_comment_inner(lines, start_line, end_line, leader)
   local leader_re = '^%s*' .. vim.pesc(leader)
@@ -241,6 +286,42 @@ M.gen_ai_spec.comment = function()
             to = { line = block.end_line, col = math.max(end_col, 1) },
             vis_mode = block.start_line ~= block.end_line and 'V' or nil,
           })
+        end
+      end
+    end
+
+    -- Inline/end-of-line simple comments: "code  // remark"
+    for _, c in ipairs(find_all_inline_simple_comments(lines, simple_leaders)) do
+      if ai_type == 'i' then
+        local _, e = lines[c.line]:find('^%s*' .. vim.pesc(c.leader), c.col_start)
+        local rest = lines[c.line]:sub((e or c.col_start) + 1)
+        local trimmed = rest:find('%S')
+        local from_col = trimmed and (e or c.col_start) + trimmed or c.col_start
+        local to_col = #lines[c.line]:match('(.-)%s*$')
+        if from_col <= to_col then
+          table.insert(regions, { from = { line = c.line, col = from_col }, to = { line = c.line, col = to_col }, vis_mode = 'v' })
+        end
+      else
+        table.insert(regions, { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end } })
+      end
+    end
+
+    -- Inline paired comments: "code /* remark */ more"
+    for _, pair in ipairs(paired_leaders) do
+      for _, c in ipairs(find_all_inline_paired_comments(lines, pair.open, pair.close)) do
+        if ai_type == 'i' then
+          local from_col = c.col_start + #pair.open
+          local to_col = c.col_end - #pair.close
+          local inner = lines[c.line]:sub(from_col, to_col)
+          local lt = inner:match('^%s*')
+          local rt = inner:match('%s*$')
+          from_col = from_col + #lt
+          to_col = to_col - #rt
+          if from_col <= to_col then
+            table.insert(regions, { from = { line = c.line, col = from_col }, to = { line = c.line, col = to_col }, vis_mode = 'v' })
+          end
+        else
+          table.insert(regions, { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end } })
         end
       end
     end

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -2,248 +2,235 @@ local M = {}
 
 M.gen_ai_spec = {}
 
--- Port of vim-textobj-comment to mini.ai textobject specification.
--- Supports both simple (// ...) and paired (/* ... */) comment delimiters.
--- Uses the 'comments' and 'commentstring' options to detect comment leaders.
-M.gen_ai_spec.comment = function()
-  -- Parse 'comments' option into {flags, leader} pairs, with 'commentstring' as fallback.
-  local function get_leaders()
-    local comments = vim.bo.comments
-    local leaders = {}
+-- Parse 'comments' option into {flags, leader} pairs, with 'commentstring' as fallback.
+-- Returns two lists: simple leaders (e.g. "//", "#") and paired leaders (e.g. {open="/*", close="*/"}).
+local function get_comment_leaders()
+  local comments = vim.bo.comments
+  local leaders = {}
 
-    if comments ~= '' then
-      for entry in vim.gsplit(comments, ',') do
-        local colon = entry:find(':')
-        if colon then
-          local flags = entry:sub(1, colon - 1)
-          local leader = entry:sub(colon + 1)
-          table.insert(leaders, { flags = flags, leader = leader })
+  if comments ~= '' then
+    for entry in vim.gsplit(comments, ',') do
+      local colon = entry:find(':')
+      if colon then
+        local flags = entry:sub(1, colon - 1)
+        local leader = entry:sub(colon + 1)
+        table.insert(leaders, { flags = flags, leader = leader })
+      end
+    end
+  end
+
+  -- Fallback to commentstring if no leaders found
+  if #leaders == 0 then
+    local cms = vim.bo.commentstring
+    if cms:find('%%s') then
+      local before, after = cms:match('^(.-)%s*%%s(.-)%s*$')
+      if before and before ~= '' and after and after ~= '' then
+        table.insert(leaders, { flags = 's', leader = before })
+        table.insert(leaders, { flags = 'e', leader = after })
+      elseif before and before ~= '' then
+        table.insert(leaders, { flags = '', leader = before })
+      end
+    end
+  end
+
+  local simple = {}
+  local paired = {} -- list of {open, close}
+
+  local se_leaders = vim.tbl_filter(function(l)
+    return l.flags:match('[se]')
+  end, leaders)
+
+  local i = 1
+  while i <= #se_leaders do
+    local s = se_leaders[i]
+    local e = se_leaders[i + 1]
+    if s and e and s.flags:match('s') and e.flags:match('e') then
+      table.insert(paired, { open = s.leader, close = e.leader })
+      i = i + 2
+    else
+      i = i + 1
+    end
+  end
+
+  for _, l in ipairs(leaders) do
+    -- Simple leaders have flags that contain only b, n, O or are empty (no s/e/m)
+    if not l.flags:match('[sem]') then
+      table.insert(simple, l.leader)
+    end
+  end
+
+  return simple, paired
+end
+
+-- Find a contiguous block of simple comment lines that includes lnum.
+local function find_simple_comment_block(lnum, simple_re)
+  if not vim.fn.getline(lnum):match(simple_re) then
+    return nil
+  end
+  local start_line = lnum
+  while start_line > 1 and vim.fn.getline(start_line - 1):match(simple_re) do
+    start_line = start_line - 1
+  end
+  local end_line = lnum
+  while end_line < vim.fn.line('$') and vim.fn.getline(end_line + 1):match(simple_re) do
+    end_line = end_line + 1
+  end
+  return start_line, end_line
+end
+
+-- Find a paired comment block (/* ... */) that contains lnum, or the nearest one above
+-- when upwards=true.
+local function find_paired_comment_block(lnum, open, close, upwards)
+  local open_re = '^%s*' .. vim.pesc(open)
+  local close_re = vim.pesc(close) .. '%s*$'
+  local total = vim.fn.line('$')
+
+  if upwards then
+    for ln = lnum - 1, 1, -1 do
+      if vim.fn.getline(ln):match(close_re) then
+        local end_line = ln
+        for sl = ln, 1, -1 do
+          if vim.fn.getline(sl):match(open_re) then
+            return sl, end_line
+          end
         end
       end
     end
-
-    -- Fallback to commentstring if no leaders found
-    if #leaders == 0 then
-      local cms = vim.bo.commentstring
-      if cms:find('%%s') then
-        local before, after = cms:match('^(.-)%s*%%s(.-)%s*$')
-        if before and before ~= '' and after and after ~= '' then
-          table.insert(leaders, { flags = 's', leader = before })
-          table.insert(leaders, { flags = 'e', leader = after })
-        elseif before and before ~= '' then
-          table.insert(leaders, { flags = '', leader = before })
-        end
-      end
-    end
-
-    -- Separate into simple and paired leaders
-    local simple = {}
-    local paired = {} -- list of {open, close}
-
-    local se_leaders = vim.tbl_filter(function(l)
-      return l.flags:match('[se]')
-    end, leaders)
-
-    local i = 1
-    while i <= #se_leaders do
-      local s = se_leaders[i]
-      local e = se_leaders[i + 1]
-      if s and e and s.flags:match('s') and e.flags:match('e') then
-        table.insert(paired, { open = s.leader, close = e.leader })
-        i = i + 2
-      else
-        i = i + 1
-      end
-    end
-
-    for _, l in ipairs(leaders) do
-      -- Simple leaders: flags contain only b, n, O or are empty (no s/e/m)
-      if not l.flags:match('[sem]') then
-        table.insert(simple, l.leader)
-      end
-    end
-
-    return simple, paired
-  end
-
-  local function escape_pattern(s)
-    return s:gsub('[%(%)%.%%%+%-%*%?%[%]%^%$]', '%%%1')
-  end
-
-  local function is_blank(lnum)
-    return vim.fn.getline(lnum):match('^%s*$') ~= nil
-  end
-
-  -- Find a contiguous block of simple comment lines that includes lnum.
-  local function find_simple_block(lnum, simple_re)
-    if not vim.fn.getline(lnum):match(simple_re) then
-      return nil
-    end
-    local start_line = lnum
-    while start_line > 1 and vim.fn.getline(start_line - 1):match(simple_re) do
-      start_line = start_line - 1
-    end
-    local end_line = lnum
-    while end_line < vim.fn.line('$') and vim.fn.getline(end_line + 1):match(simple_re) do
-      end_line = end_line + 1
-    end
-    return start_line, end_line
-  end
-
-  -- Find a paired comment block that contains or is nearest above lnum.
-  local function find_paired_block(lnum, open, close, upwards)
-    local open_re = '^%s*' .. escape_pattern(open)
-    local close_re = escape_pattern(close) .. '%s*$'
-    local total = vim.fn.line('$')
-
-    if upwards then
-      -- Search above cursor for the nearest paired comment end
-      for ln = lnum - 1, 1, -1 do
-        if vim.fn.getline(ln):match(close_re) then
-          local end_line = ln
-          -- Now find the matching open
-          for sl = ln, 1, -1 do
-            if vim.fn.getline(sl):match(open_re) then
+    return nil
+  else
+    for ln = lnum, total do
+      if vim.fn.getline(ln):match(close_re) then
+        local end_line = ln
+        for sl = end_line, 1, -1 do
+          if vim.fn.getline(sl):match(open_re) then
+            if sl <= lnum then
               return sl, end_line
             end
+            break
           end
         end
+        break
       end
-      return nil
-    else
-      -- Search from lnum downward for a paired comment containing or starting at lnum
-      for ln = lnum, total do
-        if vim.fn.getline(ln):match(close_re) then
-          local end_line = ln
-          -- Search upward from end_line for the matching open
-          for sl = end_line, 1, -1 do
-            if vim.fn.getline(sl):match(open_re) then
-              if sl <= lnum then
-                return sl, end_line
-              end
-              break
-            end
-          end
-          break
+    end
+    return nil
+  end
+end
+
+-- Build the inner region for a simple comment block: strip leaders and trailing whitespace.
+local function simple_comment_inner(start_line, end_line, simple_leaders)
+  local first_content_col = nil
+  for ln = start_line, end_line do
+    local line = vim.fn.getline(ln)
+    for _, leader in ipairs(simple_leaders) do
+      local _, e = line:find('^%s*' .. vim.pesc(leader))
+      if e then
+        local rest = line:sub(e + 1)
+        local trimmed_start = rest:find('%S')
+        if trimmed_start and not first_content_col then
+          first_content_col = e + trimmed_start
         end
+        break
       end
+    end
+  end
+  local last_line = vim.fn.getline(end_line)
+  local last_col = #last_line:match('(.-)%s*$')
+  return {
+    from = { line = start_line, col = first_content_col or 1 },
+    to = { line = end_line, col = math.max(last_col, 1) },
+  }
+end
+
+-- Build the inner region for a paired comment block: skip open/close delimiters.
+local function paired_comment_inner(start_line, end_line, open, close)
+  local open_line = vim.fn.getline(start_line)
+  local _, oe = open_line:find(vim.pesc(open))
+  local rest_after_open = open_line:sub((oe or 0) + 1)
+  local nonws = rest_after_open:find('%S')
+
+  local from_line, from_col, to_line, to_col
+
+  if nonws and start_line == end_line then
+    -- Single-line paired comment: /* content */
+    local close_line = vim.fn.getline(end_line)
+    local cs = close_line:find('%s*' .. vim.pesc(close) .. '%s*$')
+    from_line = start_line
+    from_col = (oe or 0) + nonws
+    to_line = end_line
+    to_col = (cs or #close_line + 1) - 1
+    if to_col < from_col then
       return nil
+    end
+  else
+    -- Multi-line: first non-blank char after open, last non-blank char before close
+    from_line = start_line
+    from_col = (oe or 0) + (nonws or #rest_after_open + 1)
+    if not nonws then
+      -- open delimiter is alone on its line; content starts on the next line
+      from_line = start_line + 1
+      local next_line = vim.fn.getline(from_line)
+      from_col = next_line:find('%S') or 1
+    end
+    local close_line_str = vim.fn.getline(end_line)
+    local cs = close_line_str:find('%s*' .. vim.pesc(close) .. '%s*$')
+    local content_before_close = close_line_str:sub(1, (cs or #close_line_str + 1) - 1)
+    local last_nonws = #content_before_close:match('(.-)%s*$')
+    to_line = end_line
+    to_col = last_nonws
+    if last_nonws == 0 then
+      to_line = end_line - 1
+      local prev = vim.fn.getline(to_line)
+      to_col = #prev:match('(.-)%s*$')
     end
   end
 
+  return {
+    from = { line = from_line, col = from_col },
+    to = { line = to_line, col = math.max(to_col, 1) },
+  }
+end
+
+-- Port of vim-textobj-comment to mini.ai textobject specification.
+-- Supports both simple (// ...) and paired (/* ... */) comment delimiters.
+-- Uses the 'comments' and 'commentstring' options to determine comment leaders.
+M.gen_ai_spec.comment = function()
   return function(ai_type)
-    local simple_leaders, paired_leaders = get_leaders()
+    local simple_leaders, paired_leaders = get_comment_leaders()
     if #simple_leaders == 0 and #paired_leaders == 0 then
       return nil
     end
 
     local lnum = vim.fn.line('.')
 
-    -- Build a combined simple leader pattern
+    -- Build a combined Lua pattern that matches any simple leader at line start
     local simple_re = nil
     if #simple_leaders > 0 then
-      local parts = vim.tbl_map(function(l)
-        return escape_pattern(l)
-      end, simple_leaders)
+      local parts = vim.tbl_map(vim.pesc, simple_leaders)
       simple_re = '^%s*(' .. table.concat(parts, '|') .. ')'
     end
 
     -- 1. Try simple line comment at cursor
     if simple_re then
-      local start_line, end_line = find_simple_block(lnum, simple_re)
+      local start_line, end_line = find_simple_comment_block(lnum, simple_re)
       if start_line then
         if ai_type == 'i' then
-          -- Strip comment leader from each line; select trimmed content
-          local first_content_col = nil
-          for ln = start_line, end_line do
-            local line = vim.fn.getline(ln)
-            for _, leader in ipairs(simple_leaders) do
-              local _, e = line:find('^%s*' .. escape_pattern(leader))
-              if e then
-                local rest = line:sub(e + 1)
-                local trimmed_start = rest:find('%S')
-                if trimmed_start then
-                  local col = e + trimmed_start
-                  if not first_content_col then
-                    first_content_col = col
-                  end
-                end
-                break
-              end
-            end
-          end
-          local last_line = vim.fn.getline(end_line)
-          local last_col = #last_line:match('(.-)%s*$')
-          return {
-            from = { line = start_line, col = first_content_col or 1 },
-            to = { line = end_line, col = math.max(last_col, 1) },
-          }
+          return simple_comment_inner(start_line, end_line, simple_leaders)
         else
-          -- 'a': select whole lines
           local end_col = #vim.fn.getline(end_line)
-          return {
-            from = { line = start_line, col = 1 },
-            to = { line = end_line, col = math.max(end_col, 1) },
-          }
+          return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
         end
       end
     end
 
     -- 2. Try paired comment containing or surrounding cursor
     for _, pair in ipairs(paired_leaders) do
-      local start_line, end_line = find_paired_block(lnum, pair.open, pair.close, false)
+      local start_line, end_line = find_paired_comment_block(lnum, pair.open, pair.close, false)
       if start_line then
         if ai_type == 'i' then
-          -- Inner: skip open/close delimiters
-          local from_line, from_col, to_line, to_col
-          local open_line = vim.fn.getline(start_line)
-          local _, oe = open_line:find(escape_pattern(pair.open))
-          local rest_after_open = open_line:sub((oe or 0) + 1)
-          local nonws = rest_after_open:find('%S')
-          if nonws and start_line == end_line then
-            -- Single-line paired comment
-            local close_line = vim.fn.getline(end_line)
-            local cs = close_line:find('%s*' .. escape_pattern(pair.close) .. '%s*$')
-            from_line = start_line
-            from_col = (oe or 0) + nonws
-            to_line = end_line
-            to_col = (cs or #close_line + 1) - 1
-            if to_col < from_col then
-              return nil
-            end
-          else
-            -- Multi-line: first non-blank after open, last non-blank before close
-            from_line = start_line
-            from_col = (oe or 0) + (nonws or #rest_after_open + 1)
-            if not nonws then
-              -- open is on its own line, start content from next line
-              from_line = start_line + 1
-              local next_line = vim.fn.getline(from_line)
-              local col = next_line:find('%S')
-              from_col = col or 1
-            end
-            local close_line_str = vim.fn.getline(end_line)
-            local cs = close_line_str:find('%s*' .. escape_pattern(pair.close) .. '%s*$')
-            local content_before_close = close_line_str:sub(1, (cs or #close_line_str + 1) - 1)
-            local last_nonws = #content_before_close:match('(.-)%s*$')
-            to_line = end_line
-            to_col = last_nonws
-            if last_nonws == 0 then
-              to_line = end_line - 1
-              local prev = vim.fn.getline(to_line)
-              to_col = #prev:match('(.-)%s*$')
-            end
-          end
-          return {
-            from = { line = from_line, col = from_col },
-            to = { line = to_line, col = math.max(to_col, 1) },
-          }
+          return paired_comment_inner(start_line, end_line, pair.open, pair.close)
         else
           local end_col = #vim.fn.getline(end_line)
-          return {
-            from = { line = start_line, col = 1 },
-            to = { line = end_line, col = math.max(end_col, 1) },
-          }
+          return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
         end
       end
     end
@@ -252,26 +239,20 @@ M.gen_ai_spec.comment = function()
     if simple_re then
       for ln = lnum - 1, 1, -1 do
         if vim.fn.getline(ln):match(simple_re) then
-          local start_line, end_line = find_simple_block(ln, simple_re)
+          local start_line, end_line = find_simple_comment_block(ln, simple_re)
           if start_line then
             local end_col = #vim.fn.getline(end_line)
-            return {
-              from = { line = start_line, col = 1 },
-              to = { line = end_line, col = math.max(end_col, 1) },
-            }
+            return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
           end
         end
       end
     end
 
     for _, pair in ipairs(paired_leaders) do
-      local start_line, end_line = find_paired_block(lnum, pair.open, pair.close, true)
+      local start_line, end_line = find_paired_comment_block(lnum, pair.open, pair.close, true)
       if start_line then
         local end_col = #vim.fn.getline(end_line)
-        return {
-          from = { line = start_line, col = 1 },
-          to = { line = end_line, col = math.max(end_col, 1) },
-        }
+        return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
       end
     end
 

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -62,20 +62,35 @@ local function get_comment_leaders()
   return simple, paired
 end
 
+-- Returns the simple leader that matches at the start of the given line, or nil.
+local function match_simple_leader(line, simple_leaders)
+  for _, leader in ipairs(simple_leaders) do
+    if line:match('^%s*' .. vim.pesc(leader)) then
+      return leader
+    end
+  end
+  return nil
+end
+
 -- Find a contiguous block of simple comment lines that includes lnum.
-local function find_simple_comment_block(lnum, simple_re)
-  if not vim.fn.getline(lnum):match(simple_re) then
+-- Returns start_line, end_line, matched_leader or nil.
+local function find_simple_comment_block(lnum, simple_leaders)
+  local line = vim.fn.getline(lnum)
+  local leader = match_simple_leader(line, simple_leaders)
+  if not leader then
     return nil
   end
+
+  local leader_re = '^%s*' .. vim.pesc(leader)
   local start_line = lnum
-  while start_line > 1 and vim.fn.getline(start_line - 1):match(simple_re) do
+  while start_line > 1 and vim.fn.getline(start_line - 1):match(leader_re) do
     start_line = start_line - 1
   end
   local end_line = lnum
-  while end_line < vim.fn.line('$') and vim.fn.getline(end_line + 1):match(simple_re) do
+  while end_line < vim.fn.line('$') and vim.fn.getline(end_line + 1):match(leader_re) do
     end_line = end_line + 1
   end
-  return start_line, end_line
+  return start_line, end_line, leader
 end
 
 -- Find a paired comment block (/* ... */) that contains lnum, or the nearest one above
@@ -116,20 +131,18 @@ local function find_paired_comment_block(lnum, open, close, upwards)
   end
 end
 
--- Build the inner region for a simple comment block: strip leaders and trailing whitespace.
-local function simple_comment_inner(start_line, end_line, simple_leaders)
+-- Build the inner region for a simple comment block: strip leader and trailing whitespace.
+local function simple_comment_inner(start_line, end_line, leader)
+  local leader_re = '^%s*' .. vim.pesc(leader)
   local first_content_col = nil
   for ln = start_line, end_line do
     local line = vim.fn.getline(ln)
-    for _, leader in ipairs(simple_leaders) do
-      local _, e = line:find('^%s*' .. vim.pesc(leader))
-      if e then
-        local rest = line:sub(e + 1)
-        local trimmed_start = rest:find('%S')
-        if trimmed_start and not first_content_col then
-          first_content_col = e + trimmed_start
-        end
-        break
+    local _, e = line:find(leader_re)
+    if e then
+      local rest = line:sub(e + 1)
+      local trimmed_start = rest:find('%S')
+      if trimmed_start and not first_content_col then
+        first_content_col = e + trimmed_start
       end
     end
   end
@@ -151,7 +164,7 @@ local function paired_comment_inner(start_line, end_line, open, close)
   local from_line, from_col, to_line, to_col
 
   if nonws and start_line == end_line then
-    -- Single-line paired comment: /* content */
+    -- Single-line: /* content */
     local close_line = vim.fn.getline(end_line)
     local cs = close_line:find('%s*' .. vim.pesc(close) .. '%s*$')
     from_line = start_line
@@ -202,29 +215,20 @@ M.gen_ai_spec.comment = function()
 
     local lnum = vim.fn.line('.')
 
-    -- Build a combined Lua pattern that matches any simple leader at line start
-    local simple_re = nil
-    if #simple_leaders > 0 then
-      local parts = vim.tbl_map(vim.pesc, simple_leaders)
-      simple_re = '^%s*(' .. table.concat(parts, '|') .. ')'
-    end
-
     -- 1. Try simple line comment at cursor
-    if simple_re then
-      local start_line, end_line = find_simple_comment_block(lnum, simple_re)
-      if start_line then
-        if ai_type == 'i' then
-          return simple_comment_inner(start_line, end_line, simple_leaders)
-        else
-          local end_col = #vim.fn.getline(end_line)
-          return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
-        end
+    local start_line, end_line, leader = find_simple_comment_block(lnum, simple_leaders)
+    if start_line then
+      if ai_type == 'i' then
+        return simple_comment_inner(start_line, end_line, leader)
+      else
+        local end_col = #vim.fn.getline(end_line)
+        return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
       end
     end
 
-    -- 2. Try paired comment containing or surrounding cursor
+    -- 2. Try paired comment containing cursor
     for _, pair in ipairs(paired_leaders) do
-      local start_line, end_line = find_paired_comment_block(lnum, pair.open, pair.close, false)
+      start_line, end_line = find_paired_comment_block(lnum, pair.open, pair.close, false)
       if start_line then
         if ai_type == 'i' then
           return paired_comment_inner(start_line, end_line, pair.open, pair.close)
@@ -235,21 +239,17 @@ M.gen_ai_spec.comment = function()
       end
     end
 
-    -- 3. Search upward for nearest comment
-    if simple_re then
-      for ln = lnum - 1, 1, -1 do
-        if vim.fn.getline(ln):match(simple_re) then
-          local start_line, end_line = find_simple_comment_block(ln, simple_re)
-          if start_line then
-            local end_col = #vim.fn.getline(end_line)
-            return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
-          end
-        end
+    -- 3. Search upward for nearest comment (simple first, then paired)
+    for ln = lnum - 1, 1, -1 do
+      start_line, end_line, leader = find_simple_comment_block(ln, simple_leaders)
+      if start_line then
+        local end_col = #vim.fn.getline(end_line)
+        return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }
       end
     end
 
     for _, pair in ipairs(paired_leaders) do
-      local start_line, end_line = find_paired_comment_block(lnum, pair.open, pair.close, true)
+      start_line, end_line = find_paired_comment_block(lnum, pair.open, pair.close, true)
       if start_line then
         local end_col = #vim.fn.getline(end_line)
         return { from = { line = start_line, col = 1 }, to = { line = end_line, col = math.max(end_col, 1) } }

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -215,6 +215,7 @@ M.gen_ai_spec.comment = function()
         table.insert(regions, {
           from = { line = block.start_line, col = 1 },
           to = { line = block.end_line, col = math.max(end_col, 1) },
+          vis_mode = 'V',
         })
       end
     end
@@ -231,6 +232,7 @@ M.gen_ai_spec.comment = function()
           table.insert(regions, {
             from = { line = block.start_line, col = 1 },
             to = { line = block.end_line, col = math.max(end_col, 1) },
+            vis_mode = block.start_line ~= block.end_line and 'V' or nil,
           })
         end
       end

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -48,8 +48,8 @@ local function get_comment_leaders()
   end
 
   for _, l in ipairs(leaders) do
-    -- Simple leaders have flags that contain only b, n, O or are empty (no s/e/m)
-    if not l.flags:match('[sem]') then
+    -- Simple leaders have flags that are empty or contain only b, n, O, f characters
+    if l.flags:match('^[bnOf]*$') then
       table.insert(simple, l.leader)
     end
   end

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -40,15 +40,10 @@ local function get_comment_leaders()
     return l.flags:match('[se]')
   end, leaders)
 
-  local i = 1
-  while i <= #se_leaders do
-    local s = se_leaders[i]
-    local e = se_leaders[i + 1]
-    if s and e and s.flags:match('s') and e.flags:match('e') then
+  for i = 1, #se_leaders - 1 do
+    local s, e = se_leaders[i], se_leaders[i + 1]
+    if s.flags:match('s') and e.flags:match('e') then
       table.insert(paired, { open = s.leader, close = e.leader })
-      i = i + 2
-    else
-      i = i + 1
     end
   end
 

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -8,9 +8,9 @@ local function get_comment_leaders()
   local comments = vim.bo.comments
   local leaders = {}
 
-  if comments ~= '' then
-    for entry in vim.gsplit(comments, ',') do
-      local colon = entry:find(':')
+  if comments ~= "" then
+    for entry in vim.gsplit(comments, ",") do
+      local colon = entry:find(":")
       if colon then
         local flags = entry:sub(1, colon - 1)
         local leader = entry:sub(colon + 1)
@@ -22,13 +22,13 @@ local function get_comment_leaders()
   -- Fallback to commentstring if no leaders found
   if #leaders == 0 then
     local cms = vim.bo.commentstring
-    if cms:find('%%s') then
-      local before, after = cms:match('^(.-)%s*%%s(.-)%s*$')
-      if before and before ~= '' and after and after ~= '' then
-        table.insert(leaders, { flags = 's', leader = before })
-        table.insert(leaders, { flags = 'e', leader = after })
-      elseif before and before ~= '' then
-        table.insert(leaders, { flags = '', leader = before })
+    if cms:find("%%s") then
+      local before, after = cms:match("^(.-)%s*%%s(.-)%s*$")
+      if before and before ~= "" and after and after ~= "" then
+        table.insert(leaders, { flags = "s", leader = before })
+        table.insert(leaders, { flags = "e", leader = after })
+      elseif before and before ~= "" then
+        table.insert(leaders, { flags = "", leader = before })
       end
     end
   end
@@ -37,19 +37,19 @@ local function get_comment_leaders()
   local paired = {} -- list of {open, close}
 
   local se_leaders = vim.tbl_filter(function(l)
-    return l.flags:match('[se]')
+    return l.flags:match("[se]")
   end, leaders)
 
   for i = 1, #se_leaders - 1 do
     local s, e = se_leaders[i], se_leaders[i + 1]
-    if s.flags:match('s') and e.flags:match('e') then
+    if s.flags:match("s") and e.flags:match("e") then
       table.insert(paired, { open = s.leader, close = e.leader })
     end
   end
 
   for _, l in ipairs(leaders) do
     -- Simple leaders have flags that are empty or contain only b, n, O, f characters
-    if l.flags:match('^[bnOf]*$') then
+    if l.flags:match("^[bnOf]*$") then
       table.insert(simple, l.leader)
     end
   end
@@ -60,7 +60,7 @@ end
 -- Returns the simple leader that matches at the start of the given line, or nil.
 local function match_simple_leader(line, simple_leaders)
   for _, leader in ipairs(simple_leaders) do
-    if line:match('^%s*' .. vim.pesc(leader)) then
+    if line:match("^%s*" .. vim.pesc(leader)) then
       return leader
     end
   end
@@ -76,7 +76,7 @@ local function find_all_simple_comment_blocks(lines, simple_leaders)
   while ln <= total do
     local leader = match_simple_leader(lines[ln], simple_leaders)
     if leader then
-      local leader_re = '^%s*' .. vim.pesc(leader)
+      local leader_re = "^%s*" .. vim.pesc(leader)
       local start_line = ln
       while ln < total and lines[ln + 1]:match(leader_re) do
         ln = ln + 1
@@ -93,8 +93,8 @@ end
 local function find_all_paired_comment_blocks(lines, open, close)
   local blocks = {}
   local total = #lines
-  local open_re = '^%s*' .. vim.pesc(open)
-  local close_re = vim.pesc(close) .. '%s*$'
+  local open_re = "^%s*" .. vim.pesc(open)
+  local close_re = vim.pesc(close) .. "%s*$"
   local ln = 1
   while ln <= total do
     if lines[ln]:match(open_re) then
@@ -143,16 +143,20 @@ local function find_all_inline_paired_comments(lines, open, close)
   local results = {}
   local esc_open = vim.pesc(open)
   local esc_close = vim.pesc(close)
-  local open_re = '^%s*' .. esc_open
+  local open_re = "^%s*" .. esc_open
   for ln, line in ipairs(lines) do
     -- Skip lines where the open is at line start (handled by paired block scanner)
     if not line:match(open_re) then
       local pos = 1
       while true do
         local s = line:find(esc_open, pos)
-        if not s then break end
+        if not s then
+          break
+        end
         local e = line:find(esc_close, s + #open)
-        if not e then break end
+        if not e then
+          break
+        end
         local col_end = e + #close - 1
         table.insert(results, { line = ln, col_start = s, col_end = col_end, open = open, close = close })
         pos = col_end + 1
@@ -164,25 +168,25 @@ end
 
 -- Build the inner region for a simple comment block: strip leader and trailing whitespace.
 local function simple_comment_inner(lines, start_line, end_line, leader)
-  local leader_re = '^%s*' .. vim.pesc(leader)
+  local leader_re = "^%s*" .. vim.pesc(leader)
   local first_content_col = nil
   for ln = start_line, end_line do
     local line = lines[ln]
     local _, e = line:find(leader_re)
     if e then
       local rest = line:sub(e + 1)
-      local trimmed_start = rest:find('%S')
+      local trimmed_start = rest:find("%S")
       if trimmed_start and not first_content_col then
         first_content_col = e + trimmed_start
       end
     end
   end
   local last_line = lines[end_line]
-  local last_col = #last_line:match('(.-)%s*$')
+  local last_col = #last_line:match("(.-)%s*$")
   return {
     from = { line = start_line, col = first_content_col or 1 },
     to = { line = end_line, col = math.max(last_col, 1) },
-    vis_mode = 'v',
+    vis_mode = "v",
   }
 end
 
@@ -191,14 +195,14 @@ local function paired_comment_inner(lines, start_line, end_line, open, close)
   local open_line = lines[start_line]
   local _, oe = open_line:find(vim.pesc(open))
   local rest_after_open = open_line:sub((oe or 0) + 1)
-  local nonws = rest_after_open:find('%S')
+  local nonws = rest_after_open:find("%S")
 
   local from_line, from_col, to_line, to_col
 
   if nonws and start_line == end_line then
     -- Single-line: /* content */
     local close_line = lines[end_line]
-    local cs = close_line:find('%s*' .. vim.pesc(close) .. '%s*$')
+    local cs = close_line:find("%s*" .. vim.pesc(close) .. "%s*$")
     from_line = start_line
     from_col = (oe or 0) + nonws
     to_line = end_line
@@ -209,7 +213,7 @@ local function paired_comment_inner(lines, start_line, end_line, open, close)
     return {
       from = { line = from_line, col = from_col },
       to = { line = to_line, col = to_col },
-      vis_mode = 'v',
+      vis_mode = "v",
     }
   else
     -- Multi-line: first non-blank char after open, last non-blank char before close
@@ -219,25 +223,25 @@ local function paired_comment_inner(lines, start_line, end_line, open, close)
       -- open delimiter is alone on its line; content starts on the next line
       from_line = start_line + 1
       local next_line = lines[from_line]
-      from_col = next_line:find('%S') or 1
+      from_col = next_line:find("%S") or 1
     end
     local close_line_str = lines[end_line]
-    local cs = close_line_str:find('%s*' .. vim.pesc(close) .. '%s*$')
+    local cs = close_line_str:find("%s*" .. vim.pesc(close) .. "%s*$")
     local content_before_close = close_line_str:sub(1, (cs or #close_line_str + 1) - 1)
-    local last_nonws = #content_before_close:match('(.-)%s*$')
+    local last_nonws = #content_before_close:match("(.-)%s*$")
     to_line = end_line
     to_col = last_nonws
     if last_nonws == 0 then
       to_line = end_line - 1
       local prev = lines[to_line]
-      to_col = #prev:match('(.-)%s*$')
+      to_col = #prev:match("(.-)%s*$")
     end
   end
 
   return {
     from = { line = from_line, col = from_col },
     to = { line = to_line, col = math.max(to_col, 1) },
-    vis_mode = 'v',
+    vis_mode = "v",
   }
 end
 
@@ -257,7 +261,7 @@ M.gen_ai_spec.comment = function()
     local regions = {}
 
     for _, block in ipairs(find_all_simple_comment_blocks(lines, simple_leaders)) do
-      if ai_type == 'i' then
+      if ai_type == "i" then
         local region = simple_comment_inner(lines, block.start_line, block.end_line, block.leader)
         if region then
           table.insert(regions, region)
@@ -267,14 +271,14 @@ M.gen_ai_spec.comment = function()
         table.insert(regions, {
           from = { line = block.start_line, col = 1 },
           to = { line = block.end_line, col = math.max(end_col, 1) },
-          vis_mode = 'V',
+          vis_mode = "V",
         })
       end
     end
 
     for _, pair in ipairs(paired_leaders) do
       for _, block in ipairs(find_all_paired_comment_blocks(lines, pair.open, pair.close)) do
-        if ai_type == 'i' then
+        if ai_type == "i" then
           local region = paired_comment_inner(lines, block.start_line, block.end_line, pair.open, pair.close)
           if region then
             table.insert(regions, region)
@@ -284,7 +288,7 @@ M.gen_ai_spec.comment = function()
           table.insert(regions, {
             from = { line = block.start_line, col = 1 },
             to = { line = block.end_line, col = math.max(end_col, 1) },
-            vis_mode = block.start_line ~= block.end_line and 'V' or nil,
+            vis_mode = block.start_line ~= block.end_line and "V" or nil,
           })
         end
       end
@@ -292,36 +296,48 @@ M.gen_ai_spec.comment = function()
 
     -- Inline/end-of-line simple comments: "code  // remark"
     for _, c in ipairs(find_all_inline_simple_comments(lines, simple_leaders)) do
-      if ai_type == 'i' then
-        local _, e = lines[c.line]:find('^%s*' .. vim.pesc(c.leader), c.col_start)
+      if ai_type == "i" then
+        local _, e = lines[c.line]:find("^%s*" .. vim.pesc(c.leader), c.col_start)
         local rest = lines[c.line]:sub((e or c.col_start) + 1)
-        local trimmed = rest:find('%S')
+        local trimmed = rest:find("%S")
         local from_col = trimmed and (e or c.col_start) + trimmed or c.col_start
-        local to_col = #lines[c.line]:match('(.-)%s*$')
+        local to_col = #lines[c.line]:match("(.-)%s*$")
         if from_col <= to_col then
-          table.insert(regions, { from = { line = c.line, col = from_col }, to = { line = c.line, col = to_col }, vis_mode = 'v' })
+          table.insert(
+            regions,
+            { from = { line = c.line, col = from_col }, to = { line = c.line, col = to_col }, vis_mode = "v" }
+          )
         end
       else
-        table.insert(regions, { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end }, vis_mode = 'v' })
+        table.insert(
+          regions,
+          { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end }, vis_mode = "v" }
+        )
       end
     end
 
     -- Inline paired comments: "code /* remark */ more"
     for _, pair in ipairs(paired_leaders) do
       for _, c in ipairs(find_all_inline_paired_comments(lines, pair.open, pair.close)) do
-        if ai_type == 'i' then
+        if ai_type == "i" then
           local from_col = c.col_start + #pair.open
           local to_col = c.col_end - #pair.close
           local inner = lines[c.line]:sub(from_col, to_col)
-          local lt = inner:match('^%s*')
-          local rt = inner:match('%s*$')
+          local lt = inner:match("^%s*")
+          local rt = inner:match("%s*$")
           from_col = from_col + #lt
           to_col = to_col - #rt
           if from_col <= to_col then
-            table.insert(regions, { from = { line = c.line, col = from_col }, to = { line = c.line, col = to_col }, vis_mode = 'v' })
+            table.insert(
+              regions,
+              { from = { line = c.line, col = from_col }, to = { line = c.line, col = to_col }, vis_mode = "v" }
+            )
           end
         else
-          table.insert(regions, { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end }, vis_mode = 'v' })
+          table.insert(
+            regions,
+            { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end }, vis_mode = "v" }
+          )
         end
       end
     end

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -302,7 +302,7 @@ M.gen_ai_spec.comment = function()
           table.insert(regions, { from = { line = c.line, col = from_col }, to = { line = c.line, col = to_col }, vis_mode = 'v' })
         end
       else
-        table.insert(regions, { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end } })
+        table.insert(regions, { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end }, vis_mode = 'v' })
       end
     end
 
@@ -321,7 +321,7 @@ M.gen_ai_spec.comment = function()
             table.insert(regions, { from = { line = c.line, col = from_col }, to = { line = c.line, col = to_col }, vis_mode = 'v' })
           end
         else
-          table.insert(regions, { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end } })
+          table.insert(regions, { from = { line = c.line, col = c.col_start }, to = { line = c.line, col = c.col_end }, vis_mode = 'v' })
         end
       end
     end

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -137,6 +137,7 @@ local function simple_comment_inner(lines, start_line, end_line, leader)
   return {
     from = { line = start_line, col = first_content_col or 1 },
     to = { line = end_line, col = math.max(last_col, 1) },
+    vis_mode = 'v',
   }
 end
 
@@ -160,6 +161,11 @@ local function paired_comment_inner(lines, start_line, end_line, open, close)
     if to_col < from_col then
       return nil
     end
+    return {
+      from = { line = from_line, col = from_col },
+      to = { line = to_line, col = to_col },
+      vis_mode = 'v',
+    }
   else
     -- Multi-line: first non-blank char after open, last non-blank char before close
     from_line = start_line
@@ -186,6 +192,7 @@ local function paired_comment_inner(lines, start_line, end_line, open, close)
   return {
     from = { line = from_line, col = from_col },
     to = { line = to_line, col = math.max(to_col, 1) },
+    vis_mode = 'v',
   }
 end
 

--- a/lua/zero/extra.lua
+++ b/lua/zero/extra.lua
@@ -69,16 +69,16 @@ end
 
 -- Scan the whole buffer and return all contiguous simple comment blocks as
 -- a list of {start_line, end_line, leader}.
-local function find_all_simple_comment_blocks(simple_leaders)
+local function find_all_simple_comment_blocks(lines, simple_leaders)
   local blocks = {}
-  local total = vim.fn.line('$')
+  local total = #lines
   local ln = 1
   while ln <= total do
-    local leader = match_simple_leader(vim.fn.getline(ln), simple_leaders)
+    local leader = match_simple_leader(lines[ln], simple_leaders)
     if leader then
       local leader_re = '^%s*' .. vim.pesc(leader)
       local start_line = ln
-      while ln < total and vim.fn.getline(ln + 1):match(leader_re) do
+      while ln < total and lines[ln + 1]:match(leader_re) do
         ln = ln + 1
       end
       table.insert(blocks, { start_line = start_line, end_line = ln, leader = leader })
@@ -90,18 +90,18 @@ end
 
 -- Scan the whole buffer and return all paired comment blocks (/* ... */) as
 -- a list of {start_line, end_line}.
-local function find_all_paired_comment_blocks(open, close)
+local function find_all_paired_comment_blocks(lines, open, close)
   local blocks = {}
-  local total = vim.fn.line('$')
+  local total = #lines
   local open_re = '^%s*' .. vim.pesc(open)
   local close_re = vim.pesc(close) .. '%s*$'
   local ln = 1
   while ln <= total do
-    if vim.fn.getline(ln):match(open_re) then
+    if lines[ln]:match(open_re) then
       local start_line = ln
       local found = false
       for el = ln, total do
-        if vim.fn.getline(el):match(close_re) then
+        if lines[el]:match(close_re) then
           table.insert(blocks, { start_line = start_line, end_line = el })
           ln = el
           found = true
@@ -118,11 +118,11 @@ local function find_all_paired_comment_blocks(open, close)
 end
 
 -- Build the inner region for a simple comment block: strip leader and trailing whitespace.
-local function simple_comment_inner(start_line, end_line, leader)
+local function simple_comment_inner(lines, start_line, end_line, leader)
   local leader_re = '^%s*' .. vim.pesc(leader)
   local first_content_col = nil
   for ln = start_line, end_line do
-    local line = vim.fn.getline(ln)
+    local line = lines[ln]
     local _, e = line:find(leader_re)
     if e then
       local rest = line:sub(e + 1)
@@ -132,7 +132,7 @@ local function simple_comment_inner(start_line, end_line, leader)
       end
     end
   end
-  local last_line = vim.fn.getline(end_line)
+  local last_line = lines[end_line]
   local last_col = #last_line:match('(.-)%s*$')
   return {
     from = { line = start_line, col = first_content_col or 1 },
@@ -141,8 +141,8 @@ local function simple_comment_inner(start_line, end_line, leader)
 end
 
 -- Build the inner region for a paired comment block: skip open/close delimiters.
-local function paired_comment_inner(start_line, end_line, open, close)
-  local open_line = vim.fn.getline(start_line)
+local function paired_comment_inner(lines, start_line, end_line, open, close)
+  local open_line = lines[start_line]
   local _, oe = open_line:find(vim.pesc(open))
   local rest_after_open = open_line:sub((oe or 0) + 1)
   local nonws = rest_after_open:find('%S')
@@ -151,7 +151,7 @@ local function paired_comment_inner(start_line, end_line, open, close)
 
   if nonws and start_line == end_line then
     -- Single-line: /* content */
-    local close_line = vim.fn.getline(end_line)
+    local close_line = lines[end_line]
     local cs = close_line:find('%s*' .. vim.pesc(close) .. '%s*$')
     from_line = start_line
     from_col = (oe or 0) + nonws
@@ -167,10 +167,10 @@ local function paired_comment_inner(start_line, end_line, open, close)
     if not nonws then
       -- open delimiter is alone on its line; content starts on the next line
       from_line = start_line + 1
-      local next_line = vim.fn.getline(from_line)
+      local next_line = lines[from_line]
       from_col = next_line:find('%S') or 1
     end
-    local close_line_str = vim.fn.getline(end_line)
+    local close_line_str = lines[end_line]
     local cs = close_line_str:find('%s*' .. vim.pesc(close) .. '%s*$')
     local content_before_close = close_line_str:sub(1, (cs or #close_line_str + 1) - 1)
     local last_nonws = #content_before_close:match('(.-)%s*$')
@@ -178,7 +178,7 @@ local function paired_comment_inner(start_line, end_line, open, close)
     to_col = last_nonws
     if last_nonws == 0 then
       to_line = end_line - 1
-      local prev = vim.fn.getline(to_line)
+      local prev = lines[to_line]
       to_col = #prev:match('(.-)%s*$')
     end
   end
@@ -201,16 +201,17 @@ M.gen_ai_spec.comment = function()
       return nil
     end
 
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
     local regions = {}
 
-    for _, block in ipairs(find_all_simple_comment_blocks(simple_leaders)) do
+    for _, block in ipairs(find_all_simple_comment_blocks(lines, simple_leaders)) do
       if ai_type == 'i' then
-        local region = simple_comment_inner(block.start_line, block.end_line, block.leader)
+        local region = simple_comment_inner(lines, block.start_line, block.end_line, block.leader)
         if region then
           table.insert(regions, region)
         end
       else
-        local end_col = #vim.fn.getline(block.end_line)
+        local end_col = #lines[block.end_line]
         table.insert(regions, {
           from = { line = block.start_line, col = 1 },
           to = { line = block.end_line, col = math.max(end_col, 1) },
@@ -219,14 +220,14 @@ M.gen_ai_spec.comment = function()
     end
 
     for _, pair in ipairs(paired_leaders) do
-      for _, block in ipairs(find_all_paired_comment_blocks(pair.open, pair.close)) do
+      for _, block in ipairs(find_all_paired_comment_blocks(lines, pair.open, pair.close)) do
         if ai_type == 'i' then
-          local region = paired_comment_inner(block.start_line, block.end_line, pair.open, pair.close)
+          local region = paired_comment_inner(lines, block.start_line, block.end_line, pair.open, pair.close)
           if region then
             table.insert(regions, region)
           end
         else
-          local end_col = #vim.fn.getline(block.end_line)
+          local end_col = #lines[block.end_line]
           table.insert(regions, {
             from = { line = block.start_line, col = 1 },
             to = { line = block.end_line, col = math.max(end_col, 1) },


### PR DESCRIPTION
Port `vim-textobj-comment` to a `mini.ai` textobject specification.

## Changes
- Add `M.gen_ai_spec.comment()` in `lua/zero/extra.lua`
- Add documentation in `doc/zero-extra.md`

## Features
- Simple line comments (`//`, `#`, `--`, etc.) — contiguous runs as one block
- Paired block comments (`/* ... */`, `--[[ ... ]]`)
- Inline / end-of-line comments
- Full `next`/`last` support (`anc`/`alc`, `inc`/`ilc`)
- Correct `vis_mode` — linewise for multi-line `ac`, charwise for `ic` and inline

## Known differences from vim-textobj-comment
Consecutive single-line `/* */` blocks are kept as separate regions (not merged), enabling independent next/last targeting. See `doc/zero-extra.md` for details and a drop-in merging implementation.